### PR TITLE
query list statements and items

### DIFF
--- a/edn-api/handlers/listItems.go
+++ b/edn-api/handlers/listItems.go
@@ -10,8 +10,8 @@ func GetListItems(db *database.StatementRepository) gin.HandlerFunc {
 
 	return func(c *gin.Context) {
 
-		listStatements := db.GetListStatements()
-		
+		listStatements := db.GetFullListStatements()
+
 		c.JSON(200, listStatements)
 	}
 }

--- a/edn-api/models/statement_item.go
+++ b/edn-api/models/statement_item.go
@@ -1,9 +1,20 @@
 package models
 
+import (
+	"encoding/json"
+	"errors"
+)
+
 type ListStatementItem struct {
+	Value string `json:"value"`
+}
+
+type ListStatement struct {
 	Id int `json:"id"`
 	Title string `json:"title"`
 	List []string `json:"list"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
 }
 
 type ImageStatementItem struct {
@@ -12,3 +23,11 @@ type ImageStatementItem struct {
 	Body string `json:"body"`
 	ImageSrc string `json:"imageSrc"`
 }
+
+func (u * ListStatementItem) Scan(value interface{}) error {
+	b, ok := value.([]byte)
+	if !ok {
+	  return errors.New("type assertion to []byte failed")
+	}
+	return json.Unmarshal(b, &u)
+  }


### PR DESCRIPTION
created list_statements and list_statement_items tables. Changed query to match statements to items and return in the correct format for the front end.