### PR TITLE
add sample openapi call

### DIFF
--- a/edn-api/database/statement_repository.go
+++ b/edn-api/database/statement_repository.go
@@ -35,7 +35,6 @@ func (r *StatementRepository) GetListStatementById(id string) (models.ListStatem
 
 	defer stmt.Close()
 
-
 	rows, err := stmt.Query(id)
 
 	if err != nil {

--- a/edn-api/handlers/openAI.go
+++ b/edn-api/handlers/openAI.go
@@ -1,0 +1,44 @@
+package handlers
+
+import (
+	"ednAPI/config"
+	"ednAPI/services/openAI"
+	"fmt"
+	"os"
+
+	"github.com/gin-gonic/gin"
+)
+
+//This is an example of a handler that uses the openAI service
+//Future endpoints will build on this to create suggestions for users
+func TestOpenAI() gin.HandlerFunc {
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	organization := os.Getenv("OPENAI_ORG")
+
+	config.LoadEnvironmentVariables()
+	client := openAI.NewClient(apiKey, organization)
+	
+	return func(c *gin.Context) {
+
+	r := openAI.CreateCompletionsRequest{
+		Model: "gpt-3.5-turbo",
+		Messages: []openAI.Message{
+			{
+			Role:    "user",
+			Content: "Tell me a joke",
+			},
+		},
+		Temperature: 0.7,
+		}
+
+	completions, err := client.CreateCompletions(r)
+
+	if err != nil {
+		fmt.Print(err)
+	}
+
+	fmt.Println(completions)
+
+		c.JSON(200, completions)
+	}
+}

--- a/edn-api/main.go
+++ b/edn-api/main.go
@@ -10,19 +10,19 @@ import (
 )
 
 func main() {
-    
-    database.InitDB()
 
-    r := gin.Default()
+	database.InitDB()
 
-    config := cors.DefaultConfig()
-    config.AllowOrigins = []string{"http://localhost:5173", "https://edn-react.vercel.app"}
-    config.AllowMethods = []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"}
+	r := gin.Default()
 
-    r.Use(cors.New(config))
+	config := cors.DefaultConfig()
+	config.AllowOrigins = []string{"http://localhost:5173", "https://edn-react.vercel.app"}
+	config.AllowMethods = []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"}
 
-    routes.InitializeRoutes(r, database.NewStatementRepository(database.DB))
+	r.Use(cors.New(config))
 
-    r.Run(":8080")
+	routes.InitializeRoutes(r, database.NewStatementRepository(database.DB))
+
+	r.Run(":8080")
 
 }

--- a/edn-api/routes/routes.go
+++ b/edn-api/routes/routes.go
@@ -14,5 +14,6 @@ func InitializeRoutes(r *gin.Engine, db *database.StatementRepository) {
 		api.GET("/getListStatement/:id", handlers.GetListStatementById(db))
 		api.GET("/getAllListStatements", handlers.GetAllListStatements(db))
 		api.GET("/getAllImageStatements", handlers.GetAllImageStatements(db))
+		api.GET("/testOpenAI", handlers.TestOpenAI())
 	}
 }

--- a/edn-api/services/openai/models.go
+++ b/edn-api/services/openai/models.go
@@ -1,0 +1,66 @@
+package openAI
+
+// Message represents a single message in the conversation.
+type Message struct {
+	Role    string `json:"role,omitempty"`
+	Content string `json:"content,omitempty"`
+}
+
+// CreateCompletionsRequest defines the request structure for creating completions.
+type CreateCompletionsRequest struct {
+	Model            string            `json:"model,omitempty"`
+	Messages         []Message         `json:"messages,omitempty"`
+	Prompt           []string          `json:"prompt,omitempty"`
+	Suffix           string            `json:"suffix,omitempty"`
+	MaxTokens        int               `json:"max_tokens,omitempty"`
+	Temperature      float64           `json:"temperature,omitempty"`
+	TopP             float64           `json:"top_p,omitempty"`
+	N                int               `json:"n,omitempty"`
+	Stream           bool              `json:"stream,omitempty"`
+	LogProbs         int               `json:"logprobs,omitempty"`
+	Echo             bool              `json:"echo,omitempty"`
+	Stop             []string          `json:"stop,omitempty"`
+	PresencePenalty  float64           `json:"presence_penalty,omitempty"`
+	FrequencyPenalty float64           `json:"frequency_penalty,omitempty"`
+	BestOf           int               `json:"best_of,omitempty"`
+	LogitBias        map[string]string `json:"logit_bias,omitempty"`
+	User             string            `json:"user,omitempty"`
+}
+
+type ChoiceMessage struct {
+	Role    string `json:"role,omitempty"`
+	Content string `json:"content,omitempty"`
+}
+
+type Choices struct {
+	Message      ChoiceMessage `json:"message"`
+	Text         string        `json:"text,omitempty"`
+	Index        int           `json:"index,omitempty"`
+	Logprobs     interface{}   `json:"logprobs,omitempty"`
+	FinishReason string        `json:"finish_reason,omitempty"`
+}
+
+type Usage struct {
+	PromptTokens     int `json:"prompt_tokens,omitempty"`
+	CompletionTokens int `json:"completion_tokens,omitempty"`
+	TotalTokens      int `json:"total_tokens,omitempty"`
+}
+
+// CreateCompletionsResponse defines the response structure for completion requests.
+type CreateCompletionsResponse struct {
+	ID      string    `json:"id,omitempty"`
+	Object  string    `json:"object,omitempty"`
+	Created int       `json:"created,omitempty"`
+	Model   string    `json:"model,omitempty"`
+	Choices []Choices `json:"choices,omitempty"`
+	Usage   Usage     `json:"usage,omitempty"`
+	Error   *Error    `json:"error,omitempty"`
+}
+
+// Error defines the standard error response from the API.
+type Error struct {
+	Message string      `json:"message,omitempty"`
+	Type    string      `json:"type,omitempty"`
+	Param   interface{} `json:"param,omitempty"`
+	Code    interface{} `json:"code,omitempty"`
+}

--- a/edn-api/services/openai/openAI.go
+++ b/edn-api/services/openai/openAI.go
@@ -1,0 +1,63 @@
+package openAI
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+)
+
+type Client struct {
+	apiKey       string
+	organization string
+}
+
+// NewClient creates a new client
+func NewClient(apiKey, organization string) *Client {
+	return &Client{
+		apiKey:       apiKey,
+		organization: organization,
+	}
+}
+
+func (c *Client) makeRequest(method, url string, input any) ([]byte, error) {
+	var body io.Reader
+
+	if input != nil && method == http.MethodPost {
+		rJson, err := json.Marshal(input)
+		if err != nil {
+			return nil, err
+		}
+		body = bytes.NewReader(rJson)
+	}
+
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Authorization", "Bearer "+c.apiKey)
+	req.Header.Add("Content-Type", "application/json")
+	if c.organization != "" {
+		req.Header.Add("OpenAI-Organization", c.organization)
+	}
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	return io.ReadAll(resp.Body)
+}
+
+// Post makes a post request
+func (c *Client) Post(url string, input any) ([]byte, error) {
+	return c.makeRequest(http.MethodPost, url, input)
+}
+
+// Get makes a get request
+func (c *Client) Get(url string) ([]byte, error) {
+	return c.makeRequest(http.MethodGet, url, nil)
+}

--- a/edn-api/services/openai/openAIRequests.go
+++ b/edn-api/services/openai/openAIRequests.go
@@ -1,0 +1,30 @@
+package openAI
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+const COMPLETIONS_URL = "https://api.openai.com/v1/chat/completions"
+
+// CreateCompletionsRaw sends a raw completion request to the OpenAI API.
+func (c *Client) CreateCompletionsRaw(r CreateCompletionsRequest) ([]byte, error) {
+	return c.Post(COMPLETIONS_URL, r)
+}
+
+// CreateCompletions sends a completion request and returns a structured response.
+func (c *Client) CreateCompletions(r CreateCompletionsRequest) (CreateCompletionsResponse, error) {
+	var response CreateCompletionsResponse
+
+	raw, err := c.CreateCompletionsRaw(r)
+	if err != nil {
+		return response, err
+	}
+
+	err = json.Unmarshal(raw, &response)
+	return response, err
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}

--- a/edn-react/package.json
+++ b/edn-react/package.json
@@ -18,7 +18,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.17.0",
-    "sort-by": "^1.2.0"
+    "sort-by": "^1.2.0",
+    "object-path": ">=0.11.8"
   },
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.6",


### PR DESCRIPTION
Setup skeleton for calls to OpenAI API. A test handler and endpoint was added. This should be used as a basic structure for future endpoints using this service.